### PR TITLE
Update InputfieldMapMarker.module

### DIFF
--- a/InputfieldMapMarker.module
+++ b/InputfieldMapMarker.module
@@ -205,8 +205,8 @@ _OUT;
 		$lng = $input["_{$name}_lng"]; 
 
 		$precision = 4; 
-		if(	((string) round($lat, $precision)) != ((string) round($this->defaultLat, $precision)) ||
-			((string) round($lng, $precision)) != ((string) round($this->defaultLng, $precision))) {
+		if(	((string) round($lat, $precision)) != ((string) round((float)$this->defaultLat, $precision)) ||
+			((string) round($lng, $precision)) != ((string) round((float)$this->defaultLng, $precision))) {
 
 			$marker->set('lat', $lat); 
 			$marker->set('lng', $lng); 


### PR DESCRIPTION
PHP8+ show error
Fatal Error: Uncaught TypeError: round(): Argument #1 ($num) must be of type int|float, string given in site/modules/FieldtypeMapMarker/InputfieldMapMarker.module:208 Cose $this->defaultLat and $this->defaultLng as empty string on this point.